### PR TITLE
INT-1153 - set explicit node major version (18.20)

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -1,4 +1,10 @@
-FROM cimg/ruby:3.0.5-node
+FROM node:18.20-alpine AS node_base
+
+FROM cimg/ruby:3.0.5
+
+# get node/npm binaries
+COPY --from=node_base /usr/local/bin /usr/local/bin
+COPY --from=node_base /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 
 ########################################
 ENV APP_HOME /myapp


### PR DESCRIPTION
- Using the base variant of the CircleCI ruby image instead of the `-node` variant, but copying node 18.20 binaries into it.
- This also slighlty reduces the image size (few 10s MBs in a ~2GB final image).