### PR TITLE
INT-1153 link nodejs to /usr/local/bin/nodejs

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -6,6 +6,9 @@ FROM cimg/ruby:3.0.5
 COPY --from=node_base /usr/local/bin /usr/local/bin
 COPY --from=node_base /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 
+# Create symbolic link for the nodejs path expected by rails, matches the path where CircleCI puts the binary: https://github.com/CircleCI-Public/cimg-ruby/blob/2cb03f2a4f02107a7994973c56c99978d925d779/3.0/node/Dockerfile
+RUN sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
 ########################################
 ENV APP_HOME /myapp
 ENV BUNDLE_PATH /cache

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -1,13 +1,6 @@
-FROM node:18.20-alpine AS node_base
-
 FROM cimg/ruby:3.0.5
 
-# get node/npm binaries
-COPY --from=node_base /usr/local/bin /usr/local/bin
-COPY --from=node_base /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
 
-# Create symbolic link for the nodejs path expected by rails, matches the path where CircleCI puts the binary: https://github.com/CircleCI-Public/cimg-ruby/blob/2cb03f2a4f02107a7994973c56c99978d925d779/3.0/node/Dockerfile
-RUN sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 ########################################
 ENV APP_HOME /myapp
@@ -16,7 +9,11 @@ ENV BUNDLE_PATH /cache
 #RUN sudo su -c "printf \"deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main\" > /etc/apt/sources.list"
 #RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B48AD6246925553 7638D0442B90D010 CBF8D6FD518E17E1
 #RUN sudo apt-get install debian-archive-keyring
-RUN sudo apt-get update -qq && sudo apt-get install -y build-essential
+RUN sudo apt-get update -qq && sudo apt-get install -y build-essential && sudo apt-get install curl
+
+# for Node
+RUN curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+RUN sudo apt-get install -y nodejs
 
 # for postgres
 RUN sudo apt-get install -y libpq-dev


### PR DESCRIPTION
Creates a symbolic link for nodejs on the path expected by rails, matches the path where CircleCI's image would put the binary: https://github.com/CircleCI-Public/cimg-ruby/blob/2cb03f2a4f02107a7994973c56c99978d925d779/3.0/node/Dockerfile

Fixes CircleCI builds failing with the error
```
Errno::ENOENT: No such file or directory - nodejs
```